### PR TITLE
added port selection option with -p/--ports flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ categories = ["networking"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rayon = "1.8.0"

--- a/src/core/scan_ip.rs
+++ b/src/core/scan_ip.rs
@@ -1,75 +1,123 @@
-use std::{net::TcpStream};
+use std::net::TcpStream;
+use std::sync::{ Arc, Mutex };
+use std::thread;
+use std::time::{ Duration, Instant };
+use std::io::Write;
 
-pub fn scan(ip: &str) {
-    let port_range: Vec<u16> = (1..65535).collect();
+pub fn scan(ip: &str, ports_to_scan: Option<Vec<u16>>) {
+    let ip = ip.to_string();
+    let open_ports = Arc::new(Mutex::new(Vec::new()));
 
-    let mut handles = vec![];
+    // specified ports or all ports (default)
+    //
+    // if ports_to_scan is None, scan all ports from 1 to 65535
+    // if ports_to_scan is Some, scan only the specified ports
+    let ports_vec = ports_to_scan.clone().unwrap_or((1..65535).collect::<Vec<u16>>());
+    let total_ports = ports_vec.len();
+    let completed = Arc::new(Mutex::new(0));
+    let start_time = Instant::now();
 
-    let mut open_ports = Vec::new();
-    let total_ports = port_range.len();
-    let mut completed_ports = 0;
+    // set up worker pool - use number of CPUs for optimal performance
+    let num_threads = thread
+        ::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(8);
 
-    let start_time = std::time::Instant::now();
+    if let Some(port_list) = ports_to_scan {
+        println!(
+            "Port sniffer CLI | Starting scan of {} with {} threads | Scanning {} specific ports",
+            ip,
+            num_threads,
+            port_list.len()
+        );
+    } else {
+        println!("Port sniffer CLI | Starting scan of {} with {} threads", ip, num_threads);
+    }
 
-    for port in port_range {
-        let ip = ip.to_string();
-        let handle = std::thread::spawn(move || {
-            let connection_with_timeout = TcpStream::connect_timeout(
-                &format!("{}:{}", ip, port).parse().unwrap(),
-                std::time::Duration::from_secs(1),
-            );
-            match connection_with_timeout {
-                Ok(_) => {
-                    Some(port)
-                }
-                Err(_) => {
-                    None
-                }
+    rayon::ThreadPoolBuilder
+        ::new()
+        .num_threads(num_threads)
+        .build()
+        .unwrap()
+        .scope(|s| {
+            let batch_size = 1000;
+            let port_range: Vec<Vec<u16>> = ports_vec
+                .chunks(batch_size)
+                .map(|chunk| chunk.to_vec())
+                .collect();
+
+            for batch in port_range {
+                let ip = ip.clone();
+                let open_ports = Arc::clone(&open_ports);
+                let completed = Arc::clone(&completed);
+                let start_time = start_time;
+
+                s.spawn(move |_| {
+                    let mut batch_open_ports = Vec::new();
+
+                    for port in batch {
+                        let addr = format!("{}:{}", ip, port);
+                        match
+                            TcpStream::connect_timeout(
+                                &addr.parse().unwrap(),
+                                Duration::from_millis(500)
+                            )
+                        {
+                            Ok(_) => batch_open_ports.push(port),
+                            Err(_) => {}
+                        }
+
+                        let mut completed_count = completed.lock().unwrap();
+                        *completed_count += 1;
+
+                        if *completed_count % 100 == 0 || *completed_count == total_ports {
+                            let percentage =
+                                ((*completed_count as f64) / (total_ports as f64)) * 100.0;
+                            let elapsed_time = start_time.elapsed();
+                            let time_per_port =
+                                elapsed_time.as_secs_f64() / (*completed_count as f64);
+                            let remaining_ports = total_ports - *completed_count;
+                            let remaining_time_secs = (time_per_port *
+                                (remaining_ports as f64)) as u64;
+
+                            // carriage return instead of clearing screen for smoother updates
+                            print!(
+                                "\r{:.1}% complete. ETA: {}m {}s | Ports checked: {}     ",
+                                percentage,
+                                remaining_time_secs / 60,
+                                remaining_time_secs % 60,
+                                *completed_count
+                            );
+                            let _ = std::io::stdout().flush();
+                        }
+                    }
+
+                    if !batch_open_ports.is_empty() {
+                        let mut all_open_ports = open_ports.lock().unwrap();
+                        all_open_ports.extend(batch_open_ports);
+                    }
+                });
             }
         });
-        handles.push(handle);
-        completed_ports += 1;
 
-        if handles.len() == 1000 {
-            for handle in handles {
-                if let Some(port) = handle.join().unwrap() {
-                    open_ports.push(port);
-                }
-            }
-            handles = vec![];
-        }
-
-        if completed_ports % 100 == 0 {
-            let percentage = (completed_ports as f64 / total_ports as f64) * 100.0;
-            let elapsed_time = start_time.elapsed();
-            let time_per_port = elapsed_time.as_secs_f64() / (completed_ports as f64);
-            let remaining_ports = total_ports - completed_ports;
-            let remaining_time_secs = (time_per_port * remaining_ports as f64) as u64;
-            let remaining_time_mins = remaining_time_secs / 60;
-
-            print!("\x1B[2J\x1B[1;1H");
-
-            println!("Port sniffer CLI by https://github.com/vin-ll | repository: https://github.com/vin-ll/port_sniffer_cli");
-            println!("{}% complete. Estimated time remaining: {} secs ({} mins)", percentage, remaining_time_secs, remaining_time_mins);
-        }
-    }
-
-    for handle in handles {
-        if let Some(port) = handle.join().unwrap() {
-            open_ports.push(port);
-        }
-    }
+    // end of scope, all threads will be joined here
+    let mut final_open_ports = open_ports.lock().unwrap().clone();
+    final_open_ports.sort();
 
     let elapsed_time = start_time.elapsed();
-    println!("Scan completed in {}m {}s", elapsed_time.as_secs() / 60, elapsed_time.as_secs() % 60);
+    println!(
+        "\nScan completed in {}m {}s",
+        elapsed_time.as_secs() / 60,
+        elapsed_time.as_secs() % 60
+    );
 
-    if open_ports.is_empty() {
+    if final_open_ports.is_empty() {
         println!("No open ports found.");
     } else {
         println!("STATE\tPORT\tPROTOCOL");
-        for port in open_ports {
+        for port in &final_open_ports {
             println!("OPEN\t{}\tTCP", port);
         }
+        println!("\nFound {} open ports", final_open_ports.len());
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,41 +1,52 @@
 mod core;
 
+fn print_usage(program_name: &str) {
+    println!("Usage: {} [command] [arguments]", program_name);
+    println!(" -h, --help\tDisplay this help message");
+    println!(" -v, --version\tDisplay the version of this program");
+    println!(" -s, --scan\tScan an IP address. Usage: -s [IPv4 Address]");
+    println!(" -p, --ports\tSpecify ports to scan. Usage: -p [PORT1,PORT2,...]");
+}
+
 fn main() {
-    let args: Vec<String> = std::env::args().collect::<Vec<String>>();
+    let args: Vec<String> = std::env::args().collect();
 
     if args.len() == 1 {
-        eprintln!("Error: You need to specify a command to run. Run -h or --help for more information.");
-        std::process::exit(1);
-    } 
-
-    let command: String = args[1].clone();
-
-    if command == "-h" || command == "--help" {
-        println!("Usage: {} [command] [arguments]", args[0]);
-        println!(" -h, --help\tDisplay this help message");
-        println!(" -v, --version\tDisplay the version of this program");
-        println!(" -s, --scan\tScan an IP address. Usage: -s [IPv4 Address]");
-    } else if command == "-v" || command == "--version" {
-        let version: String = env!("CARGO_PKG_VERSION").to_string();
-        println!("Version: {}", version);
-    } else if command == "-s" || command == "--scan" {
-        if args.len() == 2 {
-            println!("Usage: {} [command] [arguments]", args[0]);
-            println!(" -h, --help\tDisplay this help message");
-            println!(" -v, --version\tDisplay the version of this program");
-            println!(" -s, --scan\tScan an IP address. Usage: -s [IPv4 Address]");
-            std::process::exit(1);
-        }
-
-        let ip: String = args[2].clone();
-        core::scan_ip::scan(&ip);
-    } else {
-        println!("Usage: {} [command] [arguments]", args[0]);
-        println!(" -h, --help\tDisplay this help message");
-        println!(" -v, --version\tDisplay the version of this program");
-        println!(" -s, --scan\tScan an IP address. Usage: -s [IPv4 Address]");
+        eprintln!(
+            "Error: You need to specify a command to run. Run -h or --help for more information."
+        );
         std::process::exit(1);
     }
 
-    std::process::exit(0);
+    match args[1].as_str() {
+        "-h" | "--help" => print_usage(&args[0]),
+        "-v" | "--version" => println!("Version: {}", env!("CARGO_PKG_VERSION")),
+        "-s" | "--scan" => {
+            if args.len() == 2 {
+                print_usage(&args[0]);
+                std::process::exit(1);
+            }
+
+            let ip = &args[2];
+            let mut ports: Option<Vec<u16>> = None;
+
+            // Check for ports parameter
+            if args.len() > 4 && (args[3] == "-p" || args[3] == "--ports") {
+                ports = Some(parse_ports(&args[4]));
+            }
+
+            core::scan_ip::scan(ip, ports);
+        }
+        _ => {
+            print_usage(&args[0]);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_ports(ports_str: &str) -> Vec<u16> {
+    ports_str
+        .split(',')
+        .filter_map(|p| p.trim().parse::<u16>().ok())
+        .collect()
 }


### PR DESCRIPTION
- added option to scan specific ports with -p/--ports flag
- updated scan_ip module to accept optional port list
- modified help message to document the new feature
- added progress reporting for specific port scans

> example usage: portsniffer -s 192.168.1.1 -p 80,443,8080